### PR TITLE
Disabled \input file scanning

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -35,7 +35,8 @@ class Chktex(PythonLinter):
     config_file = ('--localrc', 'chktexrc')
     defaults = {
         '--nowarn:,+': [22, 30],
-        '--erroron:,+': [16]
+        '--erroron:,+': [16],
+        '--inputfiles=': [0]
     }
     inline_overrides = ('nowarn', 'erroron')
     comment_re = r'\s*%'


### PR DESCRIPTION
By default, ChkTeX tries to lint files referenced by \input. We only
want to lint the file we're looking at. The --inputfiles (or -I) switch
toggles this behaviour.
